### PR TITLE
Fix error with events on same day (now-*** readings)

### DIFF
--- a/FHEM/57_ABFALL.pm
+++ b/FHEM/57_ABFALL.pm
@@ -414,7 +414,7 @@ sub getEvents($){
 				}
 
 				my $dayDiff = floor(($eventDate - time) / 60 / 60 / 24 + 1);
-				next if ($eventDate < $now_time);
+				next if ($dayDiff < 0);
 
 				my $eventText = $summarys[$i];
 				# skip events of filter conditions


### PR DESCRIPTION
With changes in commit b9b9d9d2dce596f313806bcf8ab152d9f24b4c1e the error occured. Events on same day (today or now-*** readings) are filtered out or better skipped.
#5 