### PR TITLE
Abfall_getEvents.lfet - Indexfehler für die Aktion "clean summary with regex" korrigiert

### DIFF
--- a/lfet/ABFALL_getEvents.lfet
+++ b/lfet/ABFALL_getEvents.lfet
@@ -106,7 +106,7 @@
     </Action>
     <Action uId="15042154804215497">
       <Title language="German" value="clean summary with regex"/>
-      <SourceCode codeLanguage="Perl" sourceCodeType="StmtSeq" value="$summarys[$startTimeIndex] =~ s/$cleanReadingRegex//g;"/>
+      <SourceCode codeLanguage="Perl" sourceCodeType="StmtSeq" value="$summarys[$startTimeIndex-1] =~ s/$cleanReadingRegex//g;"/>
     </Action>
     <Action uId="15042158982006097">
       <Title language="German" value="put new event"/>


### PR DESCRIPTION
Hallo, 
in der Aktion bzw. in dessen erzeugtem Quelltext ist ein Indexfehler, sodass das Attribut "abfall_clear_reading_regex" nicht mehr greift.
Habe dies direkt in der lfet Datei korrigiert