### PR TITLE
regex for replace calender entries

### DIFF
--- a/FHEM/ABFALL_getEvents.pm
+++ b/FHEM/ABFALL_getEvents.pm
@@ -308,8 +308,17 @@ sub ABFALL_getEvents($) {
                                 Log3 $name, 5, "ABFALL_getEvents($name) - ABFALL_getEvents, 20180613.123304, 8, 19";
                                 # Trace <----
                                 
-                                # Action A09: clean summary with regex
-                                $summarys[$startTimeIndex-1] =~ s/$cleanReadingRegex//g;
+                                #split multiple regex struct
+                                my @SplitCleanReadingRegex = split(/;/,$cleanReadingRegex);
+                                
+                                #split each single regex struct
+                                foreach my $CleanReadingRegexSingle (@SplitCleanReadingRegex) 
+                                {
+                                    my @SplitCleanReadingRegexSingle = split(/\//,$CleanReadingRegexSingle);
+                                    
+                                    # Action A09: clean summary with regex
+                                    $summarys[$startTimeIndex-1] =~ s/@SplitCleanReadingRegexSingle[0]/@SplitCleanReadingRegexSingle[1]/g;
+                                }
                                 
                                 # Action A13/06: step / 5 / search for duplicate step
                                 $step = 5;
@@ -377,8 +386,17 @@ sub ABFALL_getEvents($) {
                                 Log3 $name, 5, "ABFALL_getEvents($name) - ABFALL_getEvents, 20180613.123304, 12, 19";
                                 # Trace <----
                                 
-                                # Action A09: clean summary with regex
-                                $summarys[$startTimeIndex-1] =~ s/$cleanReadingRegex//g;
+                                #split multiple regex struct
+                                my @SplitCleanReadingRegex = split(/;/,$cleanReadingRegex);
+                                
+                                #split each single regex struct
+                                foreach my $CleanReadingRegexSingle (@SplitCleanReadingRegex) 
+                                {
+                                    my @SplitCleanReadingRegexSingle = split(/\//,$CleanReadingRegexSingle);
+                                    
+                                    # Action A09: clean summary with regex
+                                    $summarys[$startTimeIndex-1] =~ s/@SplitCleanReadingRegexSingle[0]/@SplitCleanReadingRegexSingle[1]/g;
+                                }
                                 
                                 # Action A13/06: step / 5 / search for duplicate step
                                 $step = 5;
@@ -415,8 +433,17 @@ sub ABFALL_getEvents($) {
                         Log3 $name, 5, "ABFALL_getEvents($name) - ABFALL_getEvents, 20180613.123304, 14, 19";
                         # Trace <----
                         
-                        # Action A09: clean summary with regex
-                        $summarys[$startTimeIndex-1] =~ s/$cleanReadingRegex//g;
+                        #split multiple regex struct
+                        my @SplitCleanReadingRegex = split(/;/,$cleanReadingRegex);
+
+                        #split each single regex struct
+                        foreach my $CleanReadingRegexSingle (@SplitCleanReadingRegex) 
+                        {
+                            my @SplitCleanReadingRegexSingle = split(/\//,$CleanReadingRegexSingle);
+
+                            # Action A09: clean summary with regex
+                            $summarys[$startTimeIndex-1] =~ s/@SplitCleanReadingRegexSingle[0]/@SplitCleanReadingRegexSingle[1]/g;
+                        }
                         
                         # Action A13/06: step / 5 / search for duplicate step
                         $step = 5;


### PR DESCRIPTION
Ich habe einen Abfallkalender unseres Landkreises abboniert um die Termine in FHEM zu bekommen.
Leider ist das Naming eher schlecht als recht.
Daher möchte ich die vorhandenen Namen gegen unsere gebräuchlichen Namen austauschen.

Termineintrag: "Abfuhr: LVP"
Wunschname: "gelber Sack"

Termineintrag: "Abfuhr: Papierabfall"
Wunschname: "Papiermüll"

Termineintrag: "Abfuhr: Restabfall"
Wunschname: "Restmüll"

dazu habe ich folgendes Attribute definiert:
abfall_clear_reading_regex "Abfuhr: ;LVP/gelber Sack;Restabfall/Restmüll;Papierabfall/Papiermüll"

Jedes Such-Ersetzungspaar ist mit einem ";" getrennt.
Falls eine Ersetzung gewünscht wird, wird innerhalb dieses Such-Ersetzungspaar das Trennzeichen "/" verwendet (Suchstring/Ersetzungsstring).
Falls keine Ersetzung gewünscht wird, muss das Trennzeichen nicht angegeben werden.
Somit sollten die Änderung auch "abwärts kompatibel" sein.